### PR TITLE
Fix invalid style generation on systems with different cultures

### DIFF
--- a/RtfPipe/Html/CssString.cs
+++ b/RtfPipe/Html/CssString.cs
@@ -1,6 +1,7 @@
 using RtfPipe.Tokens;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -33,7 +34,7 @@ namespace RtfPipe.Model
         if (token is Font font)
           Append(font);
         else if (token is FontSize fontSize)
-          Append("font-size", fontSize.Value.ToPt().ToString("0.#") + "pt");
+          Append("font-size", fontSize.Value.ToPt().ToString("0.#", CultureInfo.InvariantCulture) + "pt");
         else if (token is BackgroundColor background)
           Append("background", "#" + background.Value);
         else if (token is ParagraphBackgroundColor backgroundPara)
@@ -104,8 +105,8 @@ namespace RtfPipe.Model
         {
           if (tokens.OfType<LineSpacingMultiple>().Any(m => m.Value == 1))
           {
-            if ((Math.Abs(lineSpace.Value) / 240.0).ToString("0.#") != "1")
-              Append("line-height", (Math.Abs(lineSpace.Value) * DefaultBrowserLineHeight / 240.0).ToString("0.#"));
+            if ((Math.Abs(lineSpace.Value) / 240.0).ToString("0.#", CultureInfo.InvariantCulture) != "1")
+              Append("line-height", (Math.Abs(lineSpace.Value) * DefaultBrowserLineHeight / 240.0).ToString("0.#", CultureInfo.InvariantCulture));
           }
           else if (lineSpace.Value < 0)
           {
@@ -496,7 +497,7 @@ namespace RtfPipe.Model
       {
         if (i > 0)
           _builder.Append(' ');
-        var px = values[i].ToPx().ToString("0.#");
+        var px = values[i].ToPx().ToString("0.#", CultureInfo.InvariantCulture);
         _builder.Append(px);
         if (px != "0")
           _builder.Append("px");

--- a/RtfPipe/Html/HtmlVisitor.cs
+++ b/RtfPipe/Html/HtmlVisitor.cs
@@ -1,6 +1,7 @@
 using RtfPipe.Tokens;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -532,7 +533,7 @@ namespace RtfPipe.Model
     {
       var size = IndentSize(parentStyles, newLine, tabCount);
       _writer.WriteStartElement("span");
-      _writer.WriteAttributeString("style", $"display:inline-block;width:{size.ToPx()}px");
+      _writer.WriteAttributeString("style", $"display:inline-block;width:{size.ToPx().ToString(CultureInfo.InvariantCulture)}px");
       _writer.WriteEndElement();
     }
 

--- a/RtfPipe/RtfPipe.csproj
+++ b/RtfPipe/RtfPipe.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Eric Domke</Authors>
     <Company />


### PR DESCRIPTION
Some systems use comma (,) instead of (.) as a decimal separator. This should fix this issue on all systems regardless of system's default culture.

Use invariant culture provider for string conversions everywhere.