### PR TITLE
Fixed error when convert for table have html format (thead,tbody)

### DIFF
--- a/RtfPipe/Html/HtmlVisitor.cs
+++ b/RtfPipe/Html/HtmlVisitor.cs
@@ -244,9 +244,18 @@ namespace RtfPipe.Model
 
     private void ProcessColumns(Element table)
     {
-      var boundaries = table.Elements()
-        .SelectMany(e => e.Styles.OfType<CellToken>())
-        .Select(c => c.RightBoundary)
+      // Get all RightBoundary of header,body and all rows
+      var rightBoundaries = new List<UnitValue>();
+      foreach (var mainElement in table.Elements())
+      {
+        rightBoundaries.AddRange(mainElement.Styles.OfType<CellToken>().Select(c => c.RightBoundary));
+        foreach (var row in mainElement.Elements())
+        {
+          rightBoundaries.AddRange(row.Styles.OfType<CellToken>().Select(c => c.RightBoundary));
+        }
+      }
+
+      var boundaries = rightBoundaries
         .Distinct()
         .OrderBy(v => v)
         .Select(v => new CellIndex() { RightBoundary = v })


### PR DESCRIPTION
Fixed error when run ProcessColumns function with table has special format, such as merged cell on header column, format table (thead,tbody). We have to get all RightBoundaries for all cell instead of header and body style.

The input element for ProcessColumns function:

![TableContent](https://user-images.githubusercontent.com/103553971/163132714-8ee1f474-ae62-4234-a3c9-b6b2a65af2d7.JPG)
