### PR TITLE
fix #68 ignore malformed date in {\info ..}

### DIFF
--- a/RtfPipe.Tests/GitHubIssues.cs
+++ b/RtfPipe.Tests/GitHubIssues.cs
@@ -327,6 +327,18 @@ ue\highlight0 \highlight3 Green\highlight0\par
         , "<div style=\"font-size:12pt;font-family:&quot;Microsoft Sans Serif&quot;;\"><p style=\"text-align:center;margin:0;\"><mark style=\"background:#FF0000;\">Red Background</mark><mark style=\"background:#0000FF;\">Bl</mark></p><p style=\"text-align:center;margin:0;\"><mark style=\"background:#0000FF;\">ue</mark><mark style=\"background:#00FF00;\">Green</mark></p></div>");
     }
 
+    [TestMethod]
+    public void Issue68()
+    {
+      // invalid date: {\info{\creatim\yr0\mo0\dy0\hr0\min0}...}
+      TestConvert(@"{\rtf1\ansi\ansicpg1252\deff0\deflang1031{\fonttbl{\f0\fnil\fcharset0 Verdana;} \viewkind4\uc1\pard\f0\fs18 5% Auf Patronen \par \f1\par }{\info{\creatim\yr0\mo0\dy0\hr0\min0}{\revtim\yr2021\mo12\dy31\hr11\min47}{\printim\yr0\mo0\dy0\hr0\min0}} {\f1\fnil Verdana;}}"
+        , "<div style=\"font-size:12pt;font-family:Verdana;\"><p style=\"margin:0;\"><span style=\"font-family:Verdana;\"> </span>Verdana;</p></div>");
+
+      // {\info{\creatim\yr2021\mo7\dy13\hr10\min51}{\revtim\yr2021\mo7\dy13\hr10\min52}{\printim\yr0\mo0\dy0\hr0\min0}}
+      TestConvert(@"{\rtf1\ansi\ansicpg1252\deff0\deflang1031{\fonttbl{\f0\fnil\fcharset0 Verdana;} \viewkind4\uc1\pard\f0\fs18 5% Auf Patronen \par \f1\par }{\info{\creatim\yr2021\mo7\dy13\hr10\min51}{\revtim\yr2021\mo7\dy13\hr10\min52}{\printim\yr0\mo0\dy0\hr0\min0}} {\f1\fnil Verdana;}}"
+        , "<div style=\"font-size:12pt;font-family:Verdana;\"><p style=\"margin:0;\"><span style=\"font-family:Verdana;\"> </span>Verdana;</p></div>");
+    }
+
     private void TestConvert(RtfSource rtf, string html)
     {
       var actual = Rtf.ToHtml(rtf);

--- a/RtfPipe/Parser.cs
+++ b/RtfPipe/Parser.cs
@@ -122,14 +122,19 @@ namespace RtfPipe
           else if (group.Contents.Count > 1
             && group.Contents[1] is Year yr)
           {
-            var date = new DateTime(
-              yr.Value,
-              group.Contents.OfType<Month>().FirstOrDefault()?.Value ?? 1,
-              group.Contents.OfType<Day>().FirstOrDefault()?.Value ?? 1,
-              group.Contents.OfType<Hour>().FirstOrDefault()?.Value ?? 0,
-              group.Contents.OfType<Minute>().FirstOrDefault()?.Value ?? 0,
-              group.Contents.OfType<Second>().FirstOrDefault()?.Value ?? 0);
-            document.Information[group.Contents[0]] = date;
+            try {
+              var date = new DateTime(
+                yr.Value,
+                group.Contents.OfType<Month>().FirstOrDefault()?.Value ?? 1,
+                group.Contents.OfType<Day>().FirstOrDefault()?.Value ?? 1,
+                group.Contents.OfType<Hour>().FirstOrDefault()?.Value ?? 0,
+                group.Contents.OfType<Minute>().FirstOrDefault()?.Value ?? 0,
+                group.Contents.OfType<Second>().FirstOrDefault()?.Value ?? 0);
+              document.Information[group.Contents[0]] = date;
+            }
+            catch {
+              // ignore malformed date
+            }
           }
           else if (group.Contents.Count == 1
             && group.Contents[0] is ControlWord<int> intWord)


### PR DESCRIPTION
This PR fixes #68 

If an `{\info ..}` contained a invalid date like: `{\printim\yr0\mo0\dy0\hr0\min0}` or `{\creatim\yr0\mo0\dy0\hr0\min0}`
then a `System.ArgumentOutOfRangeException` was thrown by the DateTime ctor.

This PR resolves the issue by ignoring the error since a malformed date can never be useful.

```c#
System.ArgumentOutOfRangeException Year, Month, and Day parameters describe an un-representable DateTime.
   at System.DateTime..ctor(Int32 year, Int32 month, Int32 day, Int32 hour, Int32 minute, Int32 second)
   at RtfPipe.Parser.ParseInfo(Document document, Group info)
   at RtfPipe.Parser.Parse()
   at RtfPipe.Rtf.ToHtml(RtfSource source, XmlWriter writer, RtfHtmlSettings settings)
   at RtfPipe.Rtf.ToHtml(RtfSource source, RtfHtmlSettings settings)
```